### PR TITLE
Allow optional authentication for World Shards

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -520,10 +520,10 @@ export class NsApi {
      */
     public async worldRequest(shards: string[] = [],
                               extraParams: { [name: string]: string } = {},
+                              auth?: PrivateShardsAuth,
                               disableCache: boolean = false): Promise<any>
     {
-        return await this.xmlRequest(shards, extraParams, undefined,
-                                     disableCache);
+        return await this.xmlRequest(shards, extraParams, auth, disableCache);
     }
 
     /**


### PR DESCRIPTION
The new "cards" section of the NS API can only be queried using worldRequest. A forthcoming shard called "Packs" will be available under the same system, unable to be queried with the nationRequest function but able to be called with the worldRequest function. This shard requires authentication, so what I've done should add authentication to the worldRequest so that I can continue to use this wrapper for the cards section of the API.

Unless there's more to the PrivateShardsAuth system than i'm aware of, this should work fine.